### PR TITLE
first bug fix on messaging. Date closed not getting set.

### DIFF
--- a/src/Messaging.Host/Listener.cs
+++ b/src/Messaging.Host/Listener.cs
@@ -22,7 +22,7 @@
             this.receiver = scope.Resolve<IReceiver>();
             this.consumer = new DedupingMessageConsumer(new MessageConsumer(this.receiver), this.receiver);
 
-            this.logger.Info("Started pricing-listener");
+            this.logger.Info("Started sales accounts listener");
 
             this.consumer.For("linnapps.sales-account.created")
                 .OnConsumed(m =>

--- a/src/Messaging/Handlers/SalesAccountCreatedHandler.cs
+++ b/src/Messaging/Handlers/SalesAccountCreatedHandler.cs
@@ -30,7 +30,13 @@
         {
             var content = Encoding.UTF8.GetString(message.Body);
             var resource = JsonConvert.DeserializeObject<LinnappsSalesAccountResource>(content);
-            this.salesAccountService.AddSalesAccount(new SalesAccountCreateResource { AccountId = resource.AccountId, Name = resource.AccountName });
+            this.salesAccountService.AddSalesAccount(
+                new SalesAccountCreateResource
+                    {
+                        AccountId = resource.AccountId,
+                        Name = resource.AccountName,
+                        ClosedOn = resource.DateClosed
+                    });
 
             this.rabbitTerminator.Close();
 


### PR DESCRIPTION

There is still another bug. It is failing with 

 Cannot access a disposed object. A common cause of this error is disposing a context that was resolved from dependency injection and then later trying to use the same context instance elsewhere in your application. This may occur if you are calling Dispose() on the context, or wrapping the context in a using statement. If you are using dependency injection, you should let the dependency injection container take care of disposing context instances.
Object name: 'ServiceDbContext'.