### PR TITLE
possible fix

### DIFF
--- a/src/Messaging/Handlers/SalesAccountCreatedHandler.cs
+++ b/src/Messaging/Handlers/SalesAccountCreatedHandler.cs
@@ -4,7 +4,6 @@
 
     using Linn.Common.Messaging.RabbitMQ;
     using Linn.Common.Messaging.RabbitMQ.Unicast;
-    using Linn.Common.Persistence;
     using Linn.SalesAccounts.Facade.Services;
     using Linn.SalesAccounts.Resources.Messaging;
     using Linn.SalesAccounts.Resources.SalesAccounts;
@@ -15,14 +14,11 @@
     {
         private readonly ISalesAccountService salesAccountService;
 
-        private readonly ITransactionManager transactionManager;
-
         private readonly IRabbitTerminator rabbitTerminator;
 
-        public SalesAccountCreatedHandler(ISalesAccountService salesAccountService, ITransactionManager transactionManager, IRabbitTerminator rabbitTerminator)
+        public SalesAccountCreatedHandler(ISalesAccountService salesAccountService, IRabbitTerminator rabbitTerminator)
         {
             this.salesAccountService = salesAccountService;
-            this.transactionManager = transactionManager;
             this.rabbitTerminator = rabbitTerminator;
         }
 
@@ -39,8 +35,6 @@
                     });
 
             this.rabbitTerminator.Close();
-
-            this.transactionManager.Commit();
 
             return true;
         }

--- a/tests/Unit/Messaging.Tests/SalesAccountCreatedHandlerTests/ContextBase.cs
+++ b/tests/Unit/Messaging.Tests/SalesAccountCreatedHandlerTests/ContextBase.cs
@@ -15,17 +15,14 @@
 
         protected ISalesAccountService SalesAccountService { get; set; }
 
-        protected ITransactionManager TransactionManager { get; set; }
-
         protected IRabbitTerminator RabbitTerminator { get; set; }
 
         [SetUp]
         public void EstablishContext()
         {
             this.SalesAccountService = Substitute.For<ISalesAccountService>();
-            this.TransactionManager = Substitute.For<ITransactionManager>();
             this.RabbitTerminator = Substitute.For<IRabbitTerminator>();
-            this.Sut = new SalesAccountCreatedHandler(this.SalesAccountService, this.TransactionManager, this.RabbitTerminator);
+            this.Sut = new SalesAccountCreatedHandler(this.SalesAccountService, this.RabbitTerminator);
         }
     }
 }

--- a/tests/Unit/Messaging.Tests/SalesAccountCreatedHandlerTests/WhenCreatingSalesAccount.cs
+++ b/tests/Unit/Messaging.Tests/SalesAccountCreatedHandlerTests/WhenCreatingSalesAccount.cs
@@ -55,12 +55,6 @@
         }
 
         [Test]
-        public void ShouldCommitTransaction()
-        {
-            this.TransactionManager.Received(1).Commit();
-        }
-
-        [Test]
         public void ShouldReturnTrue()
         {
             this.result.Should().BeTrue();


### PR DESCRIPTION
Possible fix for 
Cannot access a disposed object. A common cause of this error is disposing a context that was resolved from dependency injection and then later trying to use the same context instance elsewhere in your application. This may occur if you are calling Dispose() on the context, or wrapping the context in a using statement. If you are using dependency injection, you should let the dependency injection container take care of disposing context instances.
Object name: 'ServiceDbContext'.

Taking ServiceDbContext out of the hands of AutoFaq 'seems' to solve the problem. 

Any slicker suggestions would be welcome...