### PR TITLE
Allow empty fields

### DIFF
--- a/src/Domain/SalesAccount.cs
+++ b/src/Domain/SalesAccount.cs
@@ -52,9 +52,9 @@
         {
             this.CheckUpdate(discountScheme, turnoverBandUri);
 
-            if (discountScheme.DiscountSchemeUri != this.DiscountSchemeUri)
+            if (discountScheme?.DiscountSchemeUri != this.DiscountSchemeUri)
             {
-                this.UpdateDiscountScheme(new SalesAccountUpdateDiscountSchemeUriActivity(discountScheme.DiscountSchemeUri));
+                this.UpdateDiscountScheme(new SalesAccountUpdateDiscountSchemeUriActivity(discountScheme?.DiscountSchemeUri));
             }
 
             if (turnoverBandUri != this.TurnoverBandUri)
@@ -94,6 +94,16 @@
 
         private void CheckUpdate(DiscountScheme discountScheme, string turnoverBandUri)
         {
+            if (string.IsNullOrEmpty(turnoverBandUri))
+            {
+                return;
+            }
+
+            if (discountScheme == null)
+            {
+                throw new InvalidTurnoverBandException($"Cannot use turnover band {turnoverBandUri} as no discount scheme specified");
+            }
+
             if (!discountScheme.TurnoverBandUris.Contains(turnoverBandUri))
             {
                 throw new InvalidTurnoverBandException($"Discount scheme {discountScheme.Name} does not contain turnover band {turnoverBandUri}");

--- a/src/Facade/Services/SalesAccountService.cs
+++ b/src/Facade/Services/SalesAccountService.cs
@@ -93,7 +93,7 @@
             }
 
             var discountScheme = this.discountSchemeService.GetDiscountScheme(updateResource.DiscountSchemeUri);
-            if (discountScheme == null)
+            if (!string.IsNullOrEmpty(updateResource.DiscountSchemeUri) && discountScheme == null)
             {
                 return new BadRequestResult<SalesAccount>($"Could not find discount scheme {updateResource.DiscountSchemeUri}");
             }

--- a/src/Proxy/DiscountSchemeService.cs
+++ b/src/Proxy/DiscountSchemeService.cs
@@ -28,6 +28,11 @@
 
         public DiscountScheme GetDiscountScheme(string discountSchemeUri)
         {
+            if (string.IsNullOrEmpty(discountSchemeUri))
+            {
+                return null;
+            }
+
             var uri = new Uri($"{this.proxyRoot}{discountSchemeUri}", UriKind.RelativeOrAbsolute);
 
             var response = this.restClient.Get(

--- a/src/Service.Host/client/src/components/Controls.js
+++ b/src/Service.Host/client/src/components/Controls.js
@@ -22,7 +22,7 @@ class Controls extends Component {
                             </LinkContainer>
                           
                             <Button 
-                                disabled={!salesAccount.discountSchemeUri || !salesAccount.turnoverBandUri || !dirty} 
+                                disabled={!dirty} 
                                 style={{marginLeft: '20px'}} bsStyle="primary" className=" muted pull-right" 
                                 onClick={() => saveAccountUpdate(salesAccount)}>
                                 {saving 

--- a/src/Service.Host/client/src/containers/SalesAccount.js
+++ b/src/Service.Host/client/src/containers/SalesAccount.js
@@ -26,7 +26,7 @@ const mapStateToProps = ({ salesAccount, discountSchemes, turnoverBandSets }, { 
     editTurnoverBandVisible: salesAccount.editTurnoverBandVisible,
     editGrowthPartnerVisible: salesAccount.editGrowthPartnerVisible,
     editEligibleForRebateVisible: salesAccount.editEligibleForRebateVisible,
-    loading: salesAccount.loading || !discountSchemes.length || !turnoverBandSets.length,
+    loading: salesAccount.loading || !discountSchemes || !turnoverBandSets,
     dirty: salesAccount.dirty,
     saving: salesAccount.saving
 });

--- a/src/Service/Modules/SalesAccountModule.cs
+++ b/src/Service/Modules/SalesAccountModule.cs
@@ -1,9 +1,5 @@
 ﻿namespace Linn.SalesAccounts.Service.Modules
 {
-    using System.Collections.Generic;
-
-    using Linn.Common.Facade;
-    using Linn.SalesAccounts.Domain;
     using Linn.SalesAccounts.Facade.Services;
     using Linn.SalesAccounts.Resources.SalesAccounts;
 
@@ -19,7 +15,6 @@
             this.salesAccountService = salesAccountService;
 
             this.Get("/sales/accounts", _ => this.GetSalesAccounts());
-            this.Get("/sales/accounts/search", _ => this.GetSalesAccounts());
             this.Get("/sales/accounts/{id:int}", parameters => this.GetSalesAccount(parameters.id));
             this.Post("/sales/accounts", _ => this.AddSalesAccount());
             this.Put("/sales/accounts/{id:int}", parameters => this.UpdateSalesAccount(parameters.id));
@@ -29,7 +24,7 @@
         private object GetSalesAccount(int id)
         {
             var salesAccount = this.salesAccountService.GetById(id);
-            return this.Negotiate.WithModel(salesAccount);
+            return this.Negotiate.WithModel(salesAccount).WithView("Index");
         }
 
         private object GetSalesAccounts()

--- a/tests/Integration/Service.Tests/SalesAccountModuleTests/WhenGettingSalesAccountWithSearch.cs
+++ b/tests/Integration/Service.Tests/SalesAccountModuleTests/WhenGettingSalesAccountWithSearch.cs
@@ -27,7 +27,7 @@
             this.SalesAccountRepository.Get("search").Returns(new[] { this.salesAccount });
 
             this.Response = this.Browser.Get(
-                "/sales/accounts/search",
+                "/sales/accounts",
                 with =>
                     {
                         with.Header("Accept", "application/json");

--- a/tests/Unit/Domain.Tests/SalesAccountTests/WhenUpdatingEmptyDiscountSchemeToEmpty.cs
+++ b/tests/Unit/Domain.Tests/SalesAccountTests/WhenUpdatingEmptyDiscountSchemeToEmpty.cs
@@ -1,0 +1,33 @@
+﻿namespace Linn.SalesAccounts.Domain.Tests.SalesAccountTests
+{
+    using FluentAssertions;
+
+    using NUnit.Framework;
+
+    public class WhenUpdatingEmptyDiscountSchemeToEmpty : ContextBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            this.Sut.UpdateAccount(
+                null,
+                null,
+                this.Sut.EligibleForGoodCreditDiscount,
+                this.Sut.EligibleForRebate,
+                this.Sut.GrowthPartner);
+        }
+
+        [Test]
+        public void ShouldNotUpdateAccount()
+        {
+            this.Sut.DiscountSchemeUri.Should().BeNull();
+            this.Sut.TurnoverBandUri.Should().BeNull();
+        }
+
+        [Test]
+        public void ShouldAddNoActivities()
+        {
+            this.ActivitiesExcludingCreate().Should().HaveCount(0);
+        }
+    }
+}

--- a/tests/Unit/Domain.Tests/SalesAccountTests/WhenUpdatingWithEmptyTurnoverBand.cs
+++ b/tests/Unit/Domain.Tests/SalesAccountTests/WhenUpdatingWithEmptyTurnoverBand.cs
@@ -1,0 +1,42 @@
+﻿namespace Linn.SalesAccounts.Domain.Tests.SalesAccountTests
+{
+    using System.Linq;
+
+    using FluentAssertions;
+
+    using Linn.SalesAccounts.Domain.Activities.SalesAccounts;
+    using Linn.SalesAccounts.Domain.External;
+
+    using NUnit.Framework;
+
+    public class WhenUpdatingWithEmptyTurnoverBand : ContextBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            var discountScheme = new DiscountScheme { DiscountSchemeUri = "/ds/1", TurnoverBandUris = new[] { "/tb/1" } };
+            this.Sut.UpdateAccount(
+                discountScheme,
+                null,
+                this.Sut.EligibleForGoodCreditDiscount,
+                this.Sut.EligibleForRebate,
+                this.Sut.GrowthPartner);
+        }
+
+        [Test]
+        public void ShouldUpdateAccount()
+        {
+            this.Sut.DiscountSchemeUri.Should().Be("/ds/1");
+            this.Sut.TurnoverBandUri.Should().BeNull();
+        }
+
+        [Test]
+        public void ShouldAddActivities()
+        {
+            this.ActivitiesExcludingCreate().Should().HaveCount(1);
+            this.ActivitiesExcludingCreate()
+                .First(a => a is SalesAccountUpdateDiscountSchemeUriActivity)
+                .As<SalesAccountUpdateDiscountSchemeUriActivity>().DiscountSchemeUri.Should().Be("/ds/1");
+        }
+    }
+}

--- a/tests/Unit/Domain.Tests/SalesAccountTests/WhenUpdatingWithTurnoverBandButNoScheme.cs
+++ b/tests/Unit/Domain.Tests/SalesAccountTests/WhenUpdatingWithTurnoverBandButNoScheme.cs
@@ -1,0 +1,27 @@
+﻿namespace Linn.SalesAccounts.Domain.Tests.SalesAccountTests
+{
+    using System;
+
+    using FluentAssertions;
+
+    using Linn.SalesAccounts.Domain.Exceptions;
+
+    using NUnit.Framework;
+
+    public class WhenUpdatingWithTurnoverBandButNoScheme : ContextBase
+    {
+        private Action action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.action = () => this.Sut.UpdateAccount(null, "/tb/1", true, true, true);
+        }
+
+        [Test]
+        public void ShouldThrowException()
+        {
+            this.action.ShouldThrow<InvalidTurnoverBandException>();
+        }
+    }
+}

--- a/tests/Unit/Facade.Tests/SalesAccountServiceTests/WhenUpdatingSalesAccountWithNoDiscountScheme.cs
+++ b/tests/Unit/Facade.Tests/SalesAccountServiceTests/WhenUpdatingSalesAccountWithNoDiscountScheme.cs
@@ -1,0 +1,62 @@
+﻿namespace Linn.SalesAccounts.Facade.Tests.SalesAccountServiceTests
+{
+    using FluentAssertions;
+
+    using Linn.Common.Facade;
+    using Linn.SalesAccounts.Domain;
+    using Linn.SalesAccounts.Domain.Dispatchers.Messages;
+    using Linn.SalesAccounts.Domain.External;
+    using Linn.SalesAccounts.Resources.SalesAccounts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenUpdatingSalesAccountWithNoDiscountScheme : ContextBase
+    {
+        private SalesAccountUpdateResource updateResource;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.DiscountSchemeService.GetDiscountScheme("/ds/1")
+                .Returns((DiscountScheme)null);
+            this.updateResource = new SalesAccountUpdateResource
+                                      {
+                                          DiscountSchemeUri = null,
+                                          TurnoverBandUri = null,
+                                          EligibleForGoodCreditDiscount = true
+                                      };
+            this.Result = this.Sut.UpdateSalesAccount(1, this.updateResource);
+        }
+
+        [Test]
+        public void ShouldGetFromRepository()
+        {
+            this.SalesAccountRepository.Received().GetById(1);
+        }
+
+        [Test]
+        public void ShouldCommitTransaction()
+        {
+            this.TransactionManager.Received().Commit();
+        }
+
+        [Test]
+        public void ShouldSendUpdatedMessage()
+        {
+            this.SalesAccountUpdatedDispatcher.Received()
+                .SendSalesAccountUpdated(Arg.Is<SalesAccountMessage>(m => m.Id == 1));
+        }
+
+        [Test]
+        public void ShouldReturnSuccessResult()
+        {
+            this.Result.Should().BeOfType<SuccessResult<SalesAccount>>();
+            var dataResult = ((SuccessResult<SalesAccount>)this.Result).Data;
+            dataResult.DiscountSchemeUri.Should().BeNull();
+            dataResult.TurnoverBandUri.Should().BeNull();
+            dataResult.EligibleForGoodCreditDiscount.Should().BeTrue();
+        }
+    }
+}

--- a/tests/Unit/Facade.Tests/SalesAccountServiceTests/WhenUpdatingSalesAccountWithNoDiscountScheme.cs
+++ b/tests/Unit/Facade.Tests/SalesAccountServiceTests/WhenUpdatingSalesAccountWithNoDiscountScheme.cs
@@ -19,7 +19,7 @@
         [SetUp]
         public void SetUp()
         {
-            this.DiscountSchemeService.GetDiscountScheme("/ds/1")
+            this.DiscountSchemeService.GetDiscountScheme(null)
                 .Returns((DiscountScheme)null);
             this.updateResource = new SalesAccountUpdateResource
                                       {

--- a/tests/Unit/Facade.Tests/SalesAccountServiceTests/WhenUpdatingSalesAccountWithTurnoverBandButNoScheme.cs
+++ b/tests/Unit/Facade.Tests/SalesAccountServiceTests/WhenUpdatingSalesAccountWithTurnoverBandButNoScheme.cs
@@ -1,0 +1,44 @@
+﻿namespace Linn.SalesAccounts.Facade.Tests.SalesAccountServiceTests
+{
+    using FluentAssertions;
+
+    using Linn.Common.Facade;
+    using Linn.SalesAccounts.Domain;
+    using Linn.SalesAccounts.Domain.External;
+    using Linn.SalesAccounts.Resources.SalesAccounts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenUpdatingSalesAccountWithTurnoverBandButNoScheme : ContextBase
+    {
+        private SalesAccountUpdateResource updateResource;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.DiscountSchemeService.GetDiscountScheme("/ds/1")
+                .Returns((DiscountScheme)null);
+            this.updateResource = new SalesAccountUpdateResource
+                                      {
+                                          DiscountSchemeUri = null,
+                                          TurnoverBandUri = "/tb/1",
+                                          EligibleForGoodCreditDiscount = true
+                                      };
+            this.Result = this.Sut.UpdateSalesAccount(1, this.updateResource);
+        }
+
+        [Test]
+        public void ShouldNotCommitTransaction()
+        {
+            this.TransactionManager.DidNotReceive().Commit();
+        }
+
+        [Test]
+        public void ShouldReturnBadRequestResult()
+        {
+            this.Result.Should().BeOfType<BadRequestResult<SalesAccount>>();
+        }
+    }
+}


### PR DESCRIPTION

Discount schemes and turnover bands should be able to be left blank for accounts not using Linn discounting e.g. ebay accounts etc.