### PR TITLE
make UI use enviromental proxy root

### DIFF
--- a/src/Service.Host/client/src/config.js
+++ b/src/Service.Host/client/src/config.js
@@ -1,6 +1,6 @@
 ﻿const config = {
     appRoot: PROCESS.ENV.appRoot ? PROCESS.ENV.appRoot : '',
-    proxyRoot: 'http://app.linn.co.uk',
+    proxyRoot: PROCESS.ENV.proxyRoot ? PROCESS.ENV.proxyRoot : '',
     countryRoot: 'http://app.linn.co.uk'
 }
 

--- a/src/Service.Host/webpack.config.js
+++ b/src/Service.Host/webpack.config.js
@@ -86,7 +86,8 @@ module.exports = {
         new webpack.NoEmitOnErrorsPlugin(), // do not emit compiled assets that include errors
         new webpack.DefinePlugin({
             'PROCESS.ENV': {
-                'appRoot': JSON.stringify('http://localhost:51610')
+                'appRoot': JSON.stringify('http://localhost:51610'),
+                'proxyRoot': JSON.stringify('http://localhost:60395'),
             }
         })
     ]};


### PR DESCRIPTION
turns out previous PR didn't make app-sys sales-accounts call the right discount scheme service in the UI because the app had a hardcoded proxyRoot

**small PR**