### PR TITLE
Update discount scheme route

### DIFF
--- a/src/Service.Host/client/src/actions/discountSchemes.js
+++ b/src/Service.Host/client/src/actions/discountSchemes.js
@@ -2,21 +2,21 @@
 import config from '../config';
 import * as actionTypes from './index';
 
-const requestDiscountScheme = () => ({
+const requestDiscountSchemes = () => ({
     type: actionTypes.REQUEST_DISCOUNT_SCHEMES,
     payload: { }
 });
 
-const receiveDiscountScheme = data => ({
+const receiveDiscountSchemes = data => ({
     type: actionTypes.RECEIVE_DISCOUNT_SCHEMES,
     payload: { data }
 });
 
 export const fetchDiscountSchemes = () => async dispatch => {
-    dispatch(requestDiscountScheme());
+    dispatch(requestDiscountSchemes());
     try {
-        const data = await fetchJson(`${config.proxyRoot}/sales/discounting/schemes`, { headers: { 'Accept': 'application/json' } });
-        dispatch(receiveDiscountScheme(data));
+        const data = await fetchJson(`${config.proxyRoot}/sales/discounting/schemes?includeClosedSchemes=true`, { headers: { 'Accept': 'application/json' } });
+        dispatch(receiveDiscountSchemes(data));
     } catch (e) {
         alert(`Failed to fetch discount Schemes. Error: ${e.message}`);
     }

--- a/src/Service.Host/client/src/components/SalesAccount.js
+++ b/src/Service.Host/client/src/components/SalesAccount.js
@@ -43,7 +43,7 @@ class SalesAccount extends Component {
                                 title={'Discount Scheme:'} 
                                 value={discountSchemeName || 'select discount scheme'} 
                                 handleClick={editDiscountScheme} 
-                                label={discountSchemeStatus && 'Closed'} 
+                                label={discountSchemeStatus && 'Scheme Closed'} 
                             />
                             { turnoverBands && <SalesAccountItem title={'Turnover Band:'} value={turnoverBandName || 'select turnover band'} handleClick={editTurnoverBand} />}
                             <SalesAccountItem

--- a/src/Service.Host/client/src/components/SalesAccount.js
+++ b/src/Service.Host/client/src/components/SalesAccount.js
@@ -14,7 +14,7 @@ class SalesAccount extends Component {
     render() {
         const { loading,  dirty, saving, 
             hideEditModal, closeAccount, saveAccountUpdate,
-            salesAccount, discountSchemeName, turnoverBandName, discountSchemes, turnoverBands,
+            salesAccount, discountSchemeName, discountSchemeStatus, turnoverBandName, discountSchemes, turnoverBands,
             editDiscountScheme, setDiscountScheme, 
             editTurnoverBand, setTurnoverBand, 
             editEligibleForGoodCreditDiscount, setEligibleForGoodCreditDiscount,
@@ -39,7 +39,12 @@ class SalesAccount extends Component {
                                 </Col>
                             </Row>
                             <br />
-                            <SalesAccountItem title={'Discount Scheme:'} value={discountSchemeName || 'select discount scheme'} handleClick={editDiscountScheme} />
+                            <SalesAccountItem 
+                                title={'Discount Scheme:'} 
+                                value={discountSchemeName || 'select discount scheme'} 
+                                handleClick={editDiscountScheme} 
+                                label={discountSchemeStatus && 'Closed'} 
+                            />
                             { turnoverBands && <SalesAccountItem title={'Turnover Band:'} value={turnoverBandName || 'select turnover band'} handleClick={editTurnoverBand} />}
                             <SalesAccountItem
                                 title={'Eligible For Good Credit:'}

--- a/src/Service.Host/client/src/components/SalesAccountItem.js
+++ b/src/Service.Host/client/src/components/SalesAccountItem.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Grid, Row, Col, Button } from 'react-bootstrap';
+import { Grid, Row, Col, Button, Label } from 'react-bootstrap';
 
 const styles = {
     title: {
@@ -14,7 +14,7 @@ const styles = {
 
 export class SalesAccountItem extends Component {
     render() {
-        const {title, value, handleClick, displayOnly} = this.props;
+        const {title, value, handleClick, displayOnly, label} = this.props;
         return (
             <Row>
                 <Col sm={4} style={styles.title}>
@@ -23,8 +23,9 @@ export class SalesAccountItem extends Component {
                 <Col sm={4}>
                     {displayOnly 
                         ? value 
-                        : <Button bsStyle="link" style={styles.button} onClick={() => handleClick()}>{value}</Button> 
+                        : <Button bsStyle="link" style={styles.button} onClick={() => handleClick()}>{value}</Button>
                     }
+                    {label && <Label bsStyle="danger" style={{ marginLeft: 10 }}>{label}</Label>}
                 </Col>
             </Row>
         )

--- a/src/Service.Host/client/src/containers/SalesAccount.js
+++ b/src/Service.Host/client/src/containers/SalesAccount.js
@@ -13,12 +13,13 @@ import {
     editEligibleForRebate, setEligibleForRebate,
     fetchCountry
 } from '../actions/salesAccounts';
-import { getSalesAccount, getDiscountSchemeName, getTurnoverBandName, getTurnoverBands, getDiscountSchemes } from '../selectors/salesAccountSelectors';
+import { getSalesAccount, getDiscountSchemeName, getTurnoverBandName, getTurnoverBands, getDiscountSchemes, getDiscountSchemeStatus } from '../selectors/salesAccountSelectors';
 
 const mapStateToProps = ({ salesAccount, discountSchemes, turnoverBandSets }, { match }) => ({
     salesAccountUri: match.url,
     salesAccount: getSalesAccount(salesAccount),
     discountSchemeName: getDiscountSchemeName(getSalesAccount(salesAccount), discountSchemes),
+    discountSchemeStatus: getDiscountSchemeStatus(getSalesAccount(salesAccount), discountSchemes),
     turnoverBandName: getTurnoverBandName(getSalesAccount(salesAccount),turnoverBandSets),
     discountSchemes: getDiscountSchemes(discountSchemes),
     turnoverBands: getTurnoverBands(salesAccount, turnoverBandSets, discountSchemes),

--- a/src/Service.Host/client/src/containers/SalesAccount.js
+++ b/src/Service.Host/client/src/containers/SalesAccount.js
@@ -13,14 +13,14 @@ import {
     editEligibleForRebate, setEligibleForRebate,
     fetchCountry
 } from '../actions/salesAccounts';
-import { getSalesAccount, getDiscountSchemeName, getTurnoverBandName, getTurnoverBands } from '../selectors/salesAccountSelectors';
+import { getSalesAccount, getDiscountSchemeName, getTurnoverBandName, getTurnoverBands, getDiscountSchemes } from '../selectors/salesAccountSelectors';
 
 const mapStateToProps = ({ salesAccount, discountSchemes, turnoverBandSets }, { match }) => ({
     salesAccountUri: match.url,
     salesAccount: getSalesAccount(salesAccount),
     discountSchemeName: getDiscountSchemeName(getSalesAccount(salesAccount), discountSchemes),
     turnoverBandName: getTurnoverBandName(getSalesAccount(salesAccount),turnoverBandSets),
-    discountSchemes: discountSchemes,
+    discountSchemes: getDiscountSchemes(discountSchemes),
     turnoverBands: getTurnoverBands(salesAccount, turnoverBandSets, discountSchemes),
     editGoodCreditVisible: salesAccount.editGoodCreditVisible,
     editDiscountSchemeVisible: salesAccount.editDiscountSchemeVisible,

--- a/src/Service.Host/client/src/selectors/__tests__/salesAccountSelectors.js
+++ b/src/Service.Host/client/src/selectors/__tests__/salesAccountSelectors.js
@@ -1,4 +1,4 @@
-import { getSalesAccount, getDiscountSchemeName, getTurnoverBandName, getTurnoverBands } from '../salesAccountSelectors';
+import { getSalesAccount, getDiscountSchemeName, getTurnoverBandName, getTurnoverBands, getDiscountSchemes } from '../salesAccountSelectors';
 
 describe('when selecting sales account', () => {
     test('should return sales account', () => {
@@ -318,5 +318,63 @@ describe('when selecting turnover bands', () => {
         ]
         
         expect(getTurnoverBands(salesAccount, turnoverBandSets, discountSchemes)).toEqual(expectedResult);
+    });
+});
+
+describe('when selecting discount schemes', () => {
+    test('should return only open discount schemes', () => {
+        
+        const discountSchemes =  [
+            {
+                name: 'Retailer',
+                rules: [],
+                closedOn: '',
+                links: [
+                    {
+                        rel: 'self',
+                        href: '/sales/discounting/schemes/1'
+                    },
+                    {
+                        rel: 'turnover-band-set',
+                        href: '/sales/discounting/turnover-band-sets/1'
+                    }
+                ]
+            },
+            {
+                name: 'CI',
+                rules: [],
+                closedOn: '2008-09-15T15:53:00.0000000',
+                links: [
+                    {
+                        rel: 'self',
+                        href: '/sales/discounting/schemes/2'
+                    },
+                    {
+                      rel: 'turnover-band-set',
+                     href: '/sales/discounting/turnover-band-sets/2'
+                    }
+                ]
+            },
+        ]
+
+        const expectedResult = [
+            {
+                name: 'Retailer',
+                rules: [],
+                closedOn: '',
+                links: [
+                    {
+                        rel: 'self',
+                        href: '/sales/discounting/schemes/1'
+                    },
+                    {
+                        rel: 'turnover-band-set',
+                        href: '/sales/discounting/turnover-band-sets/1'
+                    }
+                ]
+            }
+        ]
+        
+        expect(getDiscountSchemes(discountSchemes)).toEqual(expectedResult);
     });
 });

--- a/src/Service.Host/client/src/selectors/salesAccountSelectors.js
+++ b/src/Service.Host/client/src/selectors/salesAccountSelectors.js
@@ -28,6 +28,14 @@ export const getTurnoverBandName = (salesAccount, turnoverBandSets) => {
     return turnoverBand ? turnoverBand.name : null;
 }
 
+export const getDiscountSchemes = (discountSchemes) => {
+    if (!discountSchemes){
+        return null;
+    }
+
+    return discountSchemes.filter(s => s.closedOn == '');
+}
+
 const getDiscountSchemeUri = (salesAccount) => {
     if (!salesAccount) {
         return null;

--- a/src/Service.Host/client/src/selectors/salesAccountSelectors.js
+++ b/src/Service.Host/client/src/selectors/salesAccountSelectors.js
@@ -15,6 +15,16 @@ export const getDiscountSchemeName = (salesAccount, discountSchemes) => {
     return discountScheme ? discountScheme.name : null;
 }
 
+export const getDiscountSchemeStatus = (salesAccount, discountSchemes) => {
+    if (!salesAccount || !discountSchemes) {
+        return null;
+    }
+
+    const discountScheme = discountSchemes.find(s => s.links.find(l => l.href === salesAccount.discountSchemeUri));
+    
+    return discountScheme ? discountScheme.closedOn : null;
+}
+
 export const getTurnoverBandName = (salesAccount, turnoverBandSets) => {
 
     if (!turnoverBandSets || !salesAccount){


### PR DESCRIPTION
Updated route to get discount schemes. Now only shows open schemes in discount scheme select modal. Accounts will still display an associated closed discount scheme. Added label to display if scheme is closed.